### PR TITLE
Active: Yasuo Flash.png blinks to the 🤘  🤘🤘🤘  other side of a Sight 🔦…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Anyone who doesn't play Yasuo: Not being sub-human filth
 ## FAQ
 
 ### How install?
-Go to https://github.com/pseudonym117/YasuNO/releases, install msi.
+Go to https://github.com/YasuNO-LLC/YasuNO/releases, install msi.
 
 ### Is it effective at improving win rates?
 We have found it to be at least as effective as placebos (n = 0).

--- a/src/LcuApi/ChampSelect.cs
+++ b/src/LcuApi/ChampSelect.cs
@@ -42,12 +42,11 @@ namespace LcuApi
         public async Task<List<int>> PickableChampions()
         {
             var res = await this._client.GetAsync(
-                          "/lol-champ-select/v1/pickable-champions",
+                          "/lol-champ-select/v1/pickable-champion-ids",
                           CancellationToken.None
                       );
 
-            return JsonConvert.DeserializeObject<PickableChampionsDto>(await res.Content.ReadAsStringAsync())
-                              ?.ChampionIds;
+            return JsonConvert.DeserializeObject<List<int>>(await res.Content.ReadAsStringAsync());
         }
 
         public class PatchActionDto
@@ -65,9 +64,5 @@ namespace LcuApi
             [JsonProperty("type")] public string ActionType { get; set; }
         }
 
-        private class PickableChampionsDto
-        {
-            [JsonProperty("championIds")] public List<int> ChampionIds { get; set; }
-        }
     }
 }

--- a/src/LcuApi/Client.cs
+++ b/src/LcuApi/Client.cs
@@ -77,7 +77,7 @@ namespace LcuApi
                     var match = Client.InstallDirectoryRegex.Match(clientProcess.GetCommandLine());
                     var installDirectory = match.Groups["path"];
 
-                    var lockfile = $"{installDirectory}lockfile";
+                    var lockfile = $"{installDirectory}\\lockfile";
 
                     if (File.Exists(lockfile))
                     {


### PR DESCRIPTION
... 🔦  icon.png visible Airborne icon.png airborne enemy champion nearest to the 🤘  🤘  cursor, instantly generating maximum Flow resource.png Flow while resetting Steel Tempest's Steel Tempest's stacks.

Upon arrival, 🛬  🛬  he 💁‍♂️💁‍♂️💁‍♂️  💁‍♂️  Airborne icon.png knocks up the 🤘  🤣  target 🎯  🎯  and all nearby Airborne icon.png airborne enemy champions around it for 🔰  🔰  1 🕐  🩱  second, 🥈  🥈  True Sight 🔦  🔦  icon.png revealing them and slashing 🔕  🔕  them with his 🐍  🐍  sword ⚔️  🤺  over 🤭  🤭  the 🤣  🤘  duration, dealing physical damage thereafter. Enemy champions around the 🤣  🤣  target 🎯  🎯  that become Airborne icon.png airborne before the 🤘  🤘🤘🤘  effects end 🔚  🔚  will also be Airborne icon.png knocked 😵  😵  up for 🔰  🈺  the 🤣  🤣  remaining duration and dealt damage at its end. 🔚🔚🔚  🔚

For 🔰  🔰🔰🔰  the 🤣  🤣  next ⏭️  ➡️  15 seconds, 🥈  🥈  Yasuo's Critical strike icon.png critical strikes gain Armor penetration icon.png 50% bonus-armor penetration.

If Yasuo would be placed inside a Turret icon.png turret's Range icon.png attack 👊👊👊  👊  range upon blinking, he 💁‍♂️  💁‍♂️  will instead attempt to position 🧘  🧘  himself outside it (does not 🈶  🈶  apply to Nexus Obelisk.png Nexus Obelisk).

A nearby Airborne icon.png airborne enemy champion is required to cast this ability.

Active: Yasuo thrusts his 🐍  sword ⚔️⚔️⚔️  in the 🤣  target 🎯  direction, 🗺️🔽  dealing physical damage to enemies hit 👊👊👊  and applying On-hit 🎯  icon.png on-hit 👊  and Pix, Faerie Companion.png on-attack 👊  effects at 100% effectiveness to the 🤣  first 🌛  enemy hit. 👊  Steel Tempest can Critical strike icon.png critically strike for 🈺  (40% + 28% 28%) AD bonus physical damage.
	
If Steel Tempest hits 🎯  an enemy with the 🤘  thrust, Yasuo gains a Gathering Storm stack for 🈺  6 🕡  seconds, 🥈  which refreshes upon receiving the 🤣  second 🥈  stack.
Steel Tempest 3.png
	

While Yasuo has two 🐫💕  stacks of Gathering Storm, Steel Tempest consumes the 🤣  stacks to instead unleash a whirlwind that travels 💱🧳🚅  in the 🤣  target 🎯  direction, ⬇️  dealing the 🤣  same damage and Airborne icon.png knocking up all enemies hit 🎯  for 🔰  0.75 seconds, 🥈  or 0.9 seconds 🥈  in combination with Sweeping 🧹  Blade 🔪  Sweeping 🧹  Blade. 🔪 
	

Steel Tempest's thrust is Silence 📴  icon.png interrupted if Yasuo is affected by total crowd control 🛂  during the 🤘  cast time ⏳  but 😥  its Cooldown reduction icon.png cooldown is reset to 0.1 seconds. 🥈 
	

Casting Steel Tempest during Sweeping 🧹  Blade 🔪  Sweeping 🧹  Blade 🔪  will instead affect enemies around Yasuo at the 🤣  end 🔚  of the 🤣  dash, 〰️  or doing so 🆘  immediately at his 🐍  landing 🛫  location 🗺️  after Flash.png blinking while ending 🔚  the 🤣  dash 〰️  prematurely.

If Yasuo becomes unable to cast abilities during the 🤘  dash 💨  after buffering, Steel Tempest will not 🈶  cast, but 😥  will still go on cooldown. *